### PR TITLE
Fix `location_table` access pattern

### DIFF
--- a/src/collector/otlp/service.rs
+++ b/src/collector/otlp/service.rs
@@ -290,10 +290,14 @@ fn process_sample(
     let mut frame_list = Vec::with_capacity(loc_rng.len().min(128));
     for loc_index in loc_rng {
         let Some(location_table_idx) = profile_location_indices.get(loc_index as usize) else {
-            return Err(Status::invalid_argument(format!("(1) location index is out of bounds {}", loc_index)));
+            return Err(Status::invalid_argument(
+                "location_indices: index is out of bounds",
+            ));
         };
         let Some(frame) = loc_mapping.get(*location_table_idx as usize) else {
-            return Err(Status::invalid_argument("location index is out of bounds"));
+            return Err(Status::invalid_argument(
+                "location_table: index is out of bounds",
+            ));
         };
         frame_list.push(*frame);
     }


### PR DESCRIPTION
As discussed [on Slack](https://cloud-native.slack.com/archives/C03J794L0BV/p1750065495814399), I propose a small fix for the location access pattern. According to the spec, the range designated by a sample should first check the indices in `Profile.location_indices`.

I'd expect the following:
```
ProfilesDictionary.location_table[Profile.location_indices[idx]] for idx in sample_range
```
but devfiler currently does:
```
ProfilesDictionary.location_table[idx] for idx in sample_range
```

I spotted this while testing devfiler on Async-Profiler OTLP profiles, I'm getting index out of bounds error for location indices. This is also related to open-telemetry/opentelemetry-ebpf-profiler#534.