### PR TITLE
fix(deps): add `libxkbcommon` to flake.nix dependencies

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -79,6 +79,7 @@
           linuxDynamicLibs = lib.makeLibraryPath (with pkgs; with xorg; [
             libGL
             libX11
+            libxkbcommon
             libXcursor
             libXrandr
             libXi


### PR DESCRIPTION
Without `libxkbcommon` the nix build seems to fail. Adding the library to flake.nix build dependencies fixes the build.