### PR TITLE
events: make kind part of traceCountId

### DIFF
--- a/src/collector/otlp/service.rs
+++ b/src/collector/otlp/service.rs
@@ -353,11 +353,6 @@ fn process_sample(
             *timestamp / 1_000
         };
 
-        let id = TraceCountId {
-            timestamp,
-            id: DB.generate_id(),
-        };
-
         let stt_idx = sample_type.type_strindex;
         let stu_idx = sample_type.unit_strindex;
         let sample_type_type = get_str(
@@ -378,6 +373,12 @@ fn process_sample(
             _ => SampleKind::Unknown,
         };
 
+        let id = TraceCountId {
+            timestamp,
+            kind,
+            id: DB.generate_id(),
+        };
+
         event_batch.insert(
             id,
             TraceCount {
@@ -387,7 +388,6 @@ fn process_sample(
                 comm: comm.clone().unwrap_or_default().to_owned(),
                 pod_name: None,
                 container_name: None,
-                kind: kind,
             },
         );
     }

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -26,7 +26,7 @@ use tracing::warn;
 /// Bump this on any breaking schema change. Both the serialization scheme for
 /// our keys and our values doesn't support schema evolution, so essentially any
 /// change other than adding or deleting tables is a breaking one.
-const DB_VERSION: u32 = 4;
+const DB_VERSION: u32 = 5;
 
 lazy_static::lazy_static! {
     /// Global database instance.

--- a/src/storage/tables/traceevents.rs
+++ b/src/storage/tables/traceevents.rs
@@ -31,14 +31,21 @@ pub enum SampleKind {
     Mixed,
     OnCPU,
     OffCPU,
+    // _MaxKind should always be the last entry
+    // in this enum.
+    _MaxKind,
 }
-impl SampleKind {
-    pub fn as_archived(&self) -> ArchivedSampleKind {
-        match self {
-            SampleKind::Unknown => ArchivedSampleKind::Unknown,
-            SampleKind::Mixed => ArchivedSampleKind::Mixed,
-            SampleKind::OnCPU => ArchivedSampleKind::OnCPU,
-            SampleKind::OffCPU => ArchivedSampleKind::OffCPU,
+
+impl TryFrom<u8> for SampleKind {
+    type Error = ();
+
+    fn try_from(value: u8) -> Result<Self, Self::Error> {
+        match value {
+            0 => Ok(SampleKind::Unknown),
+            1 => Ok(SampleKind::Mixed),
+            2 => Ok(SampleKind::OnCPU),
+            3 => Ok(SampleKind::OffCPU),
+            _ => Err(()),
         }
     }
 }
@@ -53,16 +60,18 @@ impl SampleKind {
 #[archive_attr(derive(Debug, PartialEq, Eq, Hash))]
 pub struct TraceCountId {
     pub timestamp: UtcTimestamp,
+    pub kind: SampleKind,
     pub id: u64,
 }
 
 impl TableKey for TraceCountId {
-    type B = [u8; 16];
+    type B = [u8; 17];
 
     fn from_raw(data: Self::B) -> Self {
         Self {
             timestamp: u64::from_be_bytes(data[0..8].try_into().unwrap()),
             id: u64::from_le_bytes(data[8..16].try_into().unwrap()),
+            kind: SampleKind::try_from(data[16]).unwrap_or(SampleKind::Unknown),
         }
     }
 
@@ -70,6 +79,7 @@ impl TableKey for TraceCountId {
         let mut buf = Self::B::default();
         buf[0..8].copy_from_slice(&self.timestamp.to_be_bytes());
         buf[8..16].copy_from_slice(&self.id.to_le_bytes());
+        buf[16] = self.kind as u8;
         buf
     }
 }
@@ -85,7 +95,6 @@ pub struct TraceCount {
     pub comm: String,
     pub pod_name: Option<String>,
     pub container_name: Option<String>,
-    pub kind: SampleKind,
 }
 
 new_table!(TraceEvents: TraceCountId => TraceCount {
@@ -100,41 +109,28 @@ impl TraceEvents {
         &'a self,
         start: UtcTimestamp,
         end: UtcTimestamp,
-    ) -> impl FusedIterator<Item = (TraceCountId, TableValueRef<TraceCount, SmallVec<[u8; 64]>>)> + 'a
-    {
-        let start = TraceCountId {
-            timestamp: start.into(),
-            id: 0,
-        };
-        let end = TraceCountId {
-            timestamp: end.into(),
-            id: u64::MAX,
-        };
-
-        self.range(start, end)
-    }
-
-    /// Iterate over events in the given time range with specific sample kind.
-    ///
-    /// Iteration is ascending by timestamp.
-    pub fn time_range_with_kind<'a>(
-        &'a self,
         kind: SampleKind,
-        start: UtcTimestamp,
-        end: UtcTimestamp,
     ) -> impl FusedIterator<Item = (TraceCountId, TableValueRef<TraceCount, SmallVec<[u8; 64]>>)> + 'a
     {
         let start = TraceCountId {
             timestamp: start.into(),
+            kind: kind,
             id: 0,
         };
+        let end_kind = match kind {
+            SampleKind::Unknown | SampleKind::Mixed => SampleKind::_MaxKind,
+            _ => kind,
+        };
+
         let end = TraceCountId {
             timestamp: end.into(),
+            kind: end_kind,
             id: u64::MAX,
         };
 
-        self.range(start, end)
-            .filter(move |(_id, value)| value.get().kind == kind.as_archived())
+        self.range(start, end).filter(move |(k, _)| {
+            kind == SampleKind::Unknown || kind == SampleKind::Mixed || k.kind == kind
+        })
     }
 
     /// Group the given time range into buckets and count the number of events
@@ -160,19 +156,9 @@ impl TraceEvents {
             .map(|x| (x, 0))
             .collect();
 
-        match kind {
-            SampleKind::Mixed | SampleKind::Unknown => {
-                for (k, v) in self.time_range(start, end) {
-                    let idx = (k.timestamp - start) / step;
-                    buckets[idx as usize].1 += v.get().count as u64;
-                }
-            }
-            _ => {
-                for (k, v) in self.time_range_with_kind(kind, start, end) {
-                    let idx = (k.timestamp - start) / step;
-                    buckets[idx as usize].1 += v.get().count as u64;
-                }
-            }
+        for (k, v) in self.time_range(start, end, kind) {
+            let idx = (k.timestamp - start) / step;
+            buckets[idx as usize].1 += v.get().count as u64;
         }
 
         buckets
@@ -184,12 +170,13 @@ impl TraceEvents {
     /// down-sampling and aggregates all matching events.
     pub fn sample_events(
         &self,
+        kind: SampleKind,
         start: UtcTimestamp,
         end: UtcTimestamp,
     ) -> HashMap<TraceHash, SampledTrace> {
         let mut traces = HashMap::<TraceHash, SampledTrace>::new();
 
-        for (_, trace_count) in self.time_range(start, end) {
+        for (_, trace_count) in self.time_range(start, end, kind) {
             let tc = trace_count.get();
 
             let spot = match traces.entry(tc.trace_hash) {

--- a/src/ui/tabs/flamegraph.rs
+++ b/src/ui/tabs/flamegraph.rs
@@ -342,20 +342,11 @@ fn build_flame_graph(
 ) -> FlameGraphNode {
     // Thread 1: pull events from the table.
     let (event_tx, event_rx) = mpsc::sync_channel(4096);
-    let table_task = tokio::task::spawn_blocking(move || match kind {
-        SampleKind::Mixed | SampleKind::Unknown => {
-            for (_, tc) in DB.trace_events.time_range(start, end) {
-                event_tx
-                    .send(tc)
-                    .expect("should never be closed on RX side (1)");
-            }
-        }
-        _ => {
-            for (_, tc) in DB.trace_events.time_range_with_kind(kind, start, end) {
-                event_tx
-                    .send(tc)
-                    .expect("should never be closed on RX side (1)");
-            }
+    let table_task = tokio::task::spawn_blocking(move || {
+        for (_, tc) in DB.trace_events.time_range(start, end, kind) {
+            event_tx
+                .send(tc)
+                .expect("should never be closed on RX side (1)");
         }
     });
 

--- a/src/ui/tabs/top_funcs.rs
+++ b/src/ui/tabs/top_funcs.rs
@@ -320,7 +320,7 @@ fn query_top_funcs(
     let (event_tx, event_rx) = mpsc::sync_channel(4096);
     let table_task = tokio::task::spawn_blocking(move || {
         let mut total_samples = 0;
-        for (id, trace) in DB.trace_events.time_range(start, end) {
+        for (id, trace) in DB.trace_events.time_range(start, end, SampleKind::Mixed) {
             let trace = trace.get();
             total_samples += u64::from(trace.count);
 


### PR DESCRIPTION
Simplify code by making kind part of traceCountId. This also simplifies in the future the handling of other kinds of events.

Filtering of events now also got faster, as value.get() is no longer needed to filter for a certain kind.