### PR TITLE
Bump version to v0.15.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -722,7 +722,7 @@ checksum = "96a6ac251f4a2aca6b3f91340350eab87ae57c3f127ffeb585e92bd336717991"
 
 [[package]]
 name = "devfiler"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "anyhow",
  "arc-swap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "devfiler"
-version = "0.14.0"
+version = "0.15.0"
 edition = "2021"
 rust-version = "1.88.0"
 license = "Apache-2.0"


### PR DESCRIPTION
As https://github.com/elastic/devfiler/pull/77 introduces breaking changes (https://github.com/open-telemetry/opentelemetry-proto/pull/724/), bump the version of devfiler.